### PR TITLE
Add note about downloading train_val_test_split.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Note: only tested on CUDA 11.4.
  
 ## Data
 
-Download the [raw json data](https://drive.google.com/drive/folders/1mSJBZjKC-Z5I7pLPTgb4b5ZP-Y6itvGG) from [DeepCAD](https://github.com/ChrisWu1997/DeepCAD). Unzip it under the data folder.
+Download the [raw json data](https://drive.google.com/drive/folders/1mSJBZjKC-Z5I7pLPTgb4b5ZP-Y6itvGG)  from [DeepCAD](https://github.com/ChrisWu1997/DeepCAD). Unzip it into the `data` folder in the root of this repository.   Also download the and [train_val_test_split.json](https://drive.google.com/drive/folders/1mSJBZjKC-Z5I7pLPTgb4b5ZP-Y6itvGG) and place this in the `data` folder as well.
 
 Follow these steps to convert DeepCAD data to SkexGen format:
 ```bash


### PR DESCRIPTION
# Why?

The script `parse.py` exists with

```
Loading obj data...
Traceback (most recent call last):
  File "/home/lambouj/projects/SkexGen/utils/parse.py", line 22, in <module>
    train_samples, test_samples, val_samples = parser.load_all_obj()
  File "/home/lambouj/projects/SkexGen/utils/dataset.py", line 22, in load_all_obj
    with open('../data/train_val_test_split.json') as f:
FileNotFoundError: [Errno 2] No such file or directory: '../data/train_val_test_split.json'

```

# What?
I add a note to the README to tell a user that they also need to download the deepcad `train_val_test_split.json` file.

I also add the `data` folder and a `.gitkeep` file to force git to create that folder when the repo is cloned.  Now it's super clear where to put the data downloaded from DeepCAD.